### PR TITLE
Fix stake amount calculation

### DIFF
--- a/contracts/contracts/staking/ISeason.sol
+++ b/contracts/contracts/staking/ISeason.sol
@@ -19,6 +19,11 @@ interface ISeason {
         view
         returns (uint256, uint256);
 
+    function pointsInTime(uint256 amount, uint256 blockStamp)
+        external
+        view
+        returns (uint256);
+
     function isLocked() external view returns (bool);
 
     function isEnded() external view returns (bool);
@@ -31,7 +36,9 @@ interface ISeason {
         external
         returns (uint256, uint256);
 
-    function stake(address userAddress) external returns (uint128, uint128);
+    function stake(address userAddress, uint256 amount)
+        external
+        returns (uint128);
 
     function unstake(address userAddress) external;
 

--- a/contracts/contracts/staking/SeasonOne.sol
+++ b/contracts/contracts/staking/SeasonOne.sol
@@ -152,6 +152,7 @@ contract SeasonOne is Context, ISeason {
     function pointsInTime(uint256 amount, uint256 blockStamp)
         external
         view
+        override
         returns (uint256)
     {
         return _pointsInTime(amount, blockStamp);
@@ -278,23 +279,17 @@ contract SeasonOne is Context, ISeason {
      *      have been minted in the same tx before this has been called.
      *
      * @param userAddress - the user staking their OGN
-     * @return total OGN staked
+     * @param amount - the amount of (st)OGN being staked
      * @return total points received for the user's stake
      */
-    function stake(address userAddress)
+    function stake(address userAddress, uint256 amount)
         external
         override
         onlySeries
         ready
         canStake
-        returns (uint128, uint128)
+        returns (uint128)
     {
-        IStOGN stOGN = IStOGN(series.stOGN());
-
-        // Get the amount we're staking now (the new amount of stOGN)
-        uint256 amount = stOGN.balanceOf(userAddress) -
-            stOGN.balanceAt(userAddress, block.timestamp - 1);
-
         require(amount > 0, 'SeasonOne: No incoming stOGN');
 
         // calculate stake points
@@ -318,7 +313,7 @@ contract SeasonOne is Context, ISeason {
 
         emit Stake(userAddress, amount, user.points);
 
-        return (uint128(amount), user.points);
+        return user.points;
     }
 
     /**

--- a/contracts/contracts/staking/SeasonTwo.sol
+++ b/contracts/contracts/staking/SeasonTwo.sol
@@ -155,6 +155,7 @@ contract SeasonTwo is Context, ISeason {
     function pointsInTime(uint256 amount, uint256 blockStamp)
         external
         view
+        override
         returns (uint256)
     {
         return _pointsInTime(amount, blockStamp);
@@ -281,23 +282,17 @@ contract SeasonTwo is Context, ISeason {
      *      have been minted in the same tx before this has been called.
      *
      * @param userAddress - the user staking their OGN
-     * @return total OGN staked
+     * @param amount - the amount of (st)OGN being staked
      * @return total points received for the user's stake
      */
-    function stake(address userAddress)
+    function stake(address userAddress, uint256 amount)
         external
         override
         onlySeries
         ready
         canStake
-        returns (uint128, uint128)
+        returns (uint128)
     {
-        IStOGN stOGN = IStOGN(series.stOGN());
-
-        // Get the amount we're staking now (the new amount of stOGN)
-        uint256 amount = stOGN.balanceOf(userAddress) -
-            stOGN.balanceAt(userAddress, block.timestamp - 1);
-
         require(amount > 0, 'SeasonOne: No incoming stOGN');
 
         // calculate stake points
@@ -321,7 +316,7 @@ contract SeasonTwo is Context, ISeason {
 
         emit Stake(userAddress, amount, user.points);
 
-        return (uint128(amount), user.points);
+        return user.points;
     }
 
     /**

--- a/contracts/contracts/staking/Series.sol
+++ b/contracts/contracts/staking/Series.sol
@@ -213,13 +213,12 @@ contract Series is Context, Initializable, Governable, ISeries {
             'Series: OGN transfer failed'
         );
 
-        uint128 ognStaked;
         uint128 stakePoints;
 
         // If the season is locked, we cannot stake to it
         if (!season.isLocked()) {
             sToken.mint(userAddress, amount);
-            (ognStaked, stakePoints) = season.stake(userAddress);
+            stakePoints = season.stake(userAddress, amount);
         }
         // But we may be able to pre-stake to the next season
         else {
@@ -249,10 +248,10 @@ contract Series is Context, Initializable, Governable, ISeries {
             sToken.mint(userAddress, amount);
 
             // Stake in next season
-            (ognStaked, stakePoints) = next.stake(userAddress);
+            stakePoints = next.stake(userAddress, amount);
         }
 
-        return (ognStaked, stakePoints);
+        return (sToken.balanceOf(userAddress), stakePoints);
     }
 
     /**

--- a/contracts/contracts/staking/test/SeasonPointsAttack.sol
+++ b/contracts/contracts/staking/test/SeasonPointsAttack.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * This contract used to test against a potential exploit that allows an
+ * attacker to gain more points than they're entitled to.  It does this by
+ * staking multiple times in a block exploiting the way staking amounts are
+ * calculated.
+ */
+
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+
+import {ISeason} from '../ISeason.sol';
+import {ISeries} from '../Series.sol';
+
+contract SeasonPointsAttack {
+    ISeries public series;
+    ISeason public season;
+    IERC20 public ogn;
+
+    constructor(address series_, address ogn_) {
+        series = ISeries(series_);
+        ogn = IERC20(ogn_);
+        season = ISeason(series.currentSeason());
+    }
+
+    function execute() external {
+        // Let Series manhandle our OGN
+        ogn.approve(address(series), type(uint256).max);
+
+        uint256 ognBalance = ogn.balanceOf(address(this));
+
+        require(ognBalance > 0, 'SeasonPointsAttack: No OGN balance');
+
+        uint256 expectedTotalPoints = season.pointsInTime(
+            ognBalance,
+            season.startTime()
+        );
+
+        // We're going to send one of our full balance and each of the 5
+        // subsequent  stake will be 1 OGN
+        uint256 initial = ognBalance - 5e18;
+
+        (uint256 stakedOGN, uint256 stakePoints) = series.stake(initial);
+
+        uint256 totalStakedOGN;
+        uint256 totalStakePoints;
+
+        for (uint256 i = 0; i < 5; i++) {
+            (uint256 _ogn, uint256 _points) = series.stake(1e18);
+            totalStakedOGN = _ogn;
+            totalStakePoints = _points;
+        }
+
+        require(
+            totalStakedOGN == ognBalance,
+            'SeasonPointsAttack: Unexpected OGN balance'
+        );
+        // This is asserting invalid points totals.  It should revert if
+        // things are working correctly. It should be only the amount of
+        // points for 1m OGN at the start of the season
+        require(
+            totalStakePoints > expectedTotalPoints,
+            'SeasonPointsAttack: Unexpected points totals'
+        );
+    }
+}

--- a/contracts/test/staking/bug-invalid-points.js
+++ b/contracts/test/staking/bug-invalid-points.js
@@ -1,0 +1,43 @@
+const { expect } = require('chai')
+
+const { deployWithConfirmation } = require('../../utils/deploy')
+
+const { stakingFixture } = require('../_fixture')
+const {
+  ONE_THOUSAND_OGN,
+  loadFixture,
+  snapshot,
+  rollback
+} = require('../helpers')
+
+describe('Staking Bug - More points of repeat stakes', () => {
+  let fundOGN, fixture, snapshotId, attack
+
+  before(async function () {
+    snapshotId = await snapshot()
+    await deployments.fixture()
+
+    fixture = await loadFixture(stakingFixture)
+    fundOGN = fixture.fundOGN
+
+    await deployWithConfirmation('SeasonPointsAttack', [
+      fixture.series.address,
+      fixture.mockOGN.address
+    ])
+
+    attack = await ethers.getContract('SeasonPointsAttack')
+  })
+
+  after(async function () {
+    await rollback(snapshotId)
+  })
+
+  it('attack contract reverts', async function () {
+    // Give the attack contract 1m OGN
+    await fundOGN(attack.address, ONE_THOUSAND_OGN.mul(1000))
+
+    await expect(attack.execute()).to.be.revertedWith(
+      'SeasonPointsAttack: Unexpected points totals'
+    )
+  })
+})


### PR DESCRIPTION
Replaces stake amount inference for explicit amounts to prevent invalid points calculation exploit.